### PR TITLE
paginate to return items, getAll to use concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+test.js

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = class {
      * @param {eachPage} eachPage Callback for each page provided by endpoint
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'}). Page & limit can be passed to control start & page size.
      */
-     async paginate(endpoint, queries={}){
+     async paginate(endpoint, queries={}) {
         const _paginate = (accum = [], current) => {
             const total = this.meta.pagination.total_pages;
             queries.page = current + 1;

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = class {
      async paginate(endpoint, queries={}){
         const _paginate = (accum = [], current) => {
             const total = this.meta.pagination.total_pages;
-            queries.page = current;
+            queries.page = current + 1;
 
             if (this.debug) console.log('CURRENT PAGE:', current, 'TOTAL PAGES:', total);
 
@@ -63,7 +63,7 @@ module.exports = class {
                 return _paginate([...accum, this.get(endpoint, queries)], current + 1)
             } else return accum;
         }
-        return _paginate([await this.get(endpoint, queries)], 2);
+        return _paginate([await this.get(endpoint, queries)], 1);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -53,21 +53,17 @@ module.exports = class {
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'}). Page & limit can be passed to control start & page size.
      */
      async paginate(endpoint, queries={}){
-        await this.get(endpoint, queries)
-        let current = this.meta.pagination.current_page
-        const total = this.meta.pagination.total_pages
-
-        if (this.debug) console.log('CURRENT PAGE:', current, 'TOTAL PAGES:', total);
-
-        let res = [];
-        while(current < total) {
-            current++;
+        const _paginate = (accum = [], current) => {
+            const total = this.meta.pagination.total_pages;
             queries.page = current;
-            res.push(this.get(endpoint, queries));
-            if (this.debug) console.log('CURRENT PAGE:', current, 'TOTAL PAGES:', total);
-        }
 
-        return res;
+            if (this.debug) console.log('CURRENT PAGE:', current, 'TOTAL PAGES:', total);
+
+            if(current < total) {
+                return _paginate([...accum, this.get(endpoint, queries)], current + 1)
+            } else return accum;
+        }
+        return _paginate([await this.get(endpoint, queries)], 2);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,37 @@
 {
   "name": "bigcommerce-client",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "1.2.2",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.2.2",
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    }
+  },
   "dependencies": {
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "bigcommerce-client",
   "version": "1.2.2",
   "description": "Simple API client for the BigCommerce Management API",
-  "keywords":["BigCommerce", "API", "Client"],
+  "keywords": [
+    "BigCommerce",
+    "API",
+    "Client"
+  ],
   "main": "index.js",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/hunterashaw/bigcommerce-client.git"
+    "type": "git",
+    "url": "https://github.com/hunterashaw/bigcommerce-client.git"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,6 +18,7 @@
   "author": "Hunter Shaw",
   "license": "ISC",
   "dependencies": {
+    "bluebird": "^3.7.2",
     "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
@hunterashaw This is a rough draft and I'd want to make some more changes before committing.

I have two goals in mind.  One is to avoid state mutation, which is why I removed `paginate()`'s callback function and changed it to return an array of items.  I'd like to find a way to refactor `res` and `current` so that we don't reassign their values.

Second is to take advantage of BC's concurrency limit.  I've used Bluebird's Promise.map function.  There may be a better function to use in this case.  It requires a mapper function as an argument, but we don't need to transform our array, so mapper just returns the value untransformed.