### PR TITLE
Convert `paginate` to an AsyncGenerator to allow efficient use of data as it comes in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 test.js
+.idea/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "printWidth": 100,
+  "semi": false
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,18 @@
-/// <reference types="node" />
+import { ParsedUrlQueryInput } from "querystring";
+
 export default class BigCommerceClient {
-    base: string;
+    base: string
     headers: {
-        'X-Auth-Token': string;
-        'Accept': 'application/json';
-        'Content-Type': 'application/json';
-    };
-    meta: object;
-    debug: boolean;
-    status?: number;
-    maxAttempts: number;
-    timeout: number;
+        "X-Auth-Token": string
+        Accept: "application/json"
+        "Content-Type": "application/json"
+    }
+    meta: object
+    debug: boolean
+    status?: number
+    maxAttempts: number
+    timeout: number
+
     /**
      * Construct BigCommerceClient Instance.
      * @param {string} hash Store Hash (ex: gha3w9n1at)
@@ -19,7 +21,13 @@ export default class BigCommerceClient {
      * @param {number} timeout Max time in millis for timeout (default: 15000)
      * @param {number} maxAttempts Number of retry attempts on timeout (default: 3)
      */
-    constructor(hash: string, token: string, debug?: boolean, timeout?: number, maxAttempts?: number)
+    constructor(
+        hash: string,
+        token: string,
+        debug?: boolean,
+        timeout?: number,
+        maxAttempts?: number
+    )
 
     /**
      * Performs a GET request to the BigCommerce Management API at the specified endpoint. Throws error w/ http status information if non-200 response is returned.
@@ -37,17 +45,20 @@ export default class BigCommerceClient {
 
     /**
      * Performs sequential GET requests to the BigCommerce Management API at the specified endpoint. For each page in query it will perform the provided callback, passing an array of objects in page.
-     * @async
-     * @returns {Promise}
-     * @param {string} endoint Url endpoint from version onward (example: 'v3/catalog/products')
-     * @param {eachPage} eachPage Callback for each page provided by endpoint
+     * @generator
+     * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'}). Page & limit can be passed to control start & page size.
-     * @param {number} concurrency Amount of concurrent requests to make. Isn't a
+     * @param {number} concurrency Amount of concurrent requests to make
+     * @yields {Promise<[Array, number, number]>}
      */
-    paginate(endpoint: string, eachPage: (page: object[]) => void, queries?: object, concurrency?: number): Promise<void>
+    paginate<T>(
+        endpoint: string,
+        queries?: object,
+        concurrency?: number
+    ): AsyncGenerator<[Array<T>, number, number], never, void>
 
     /**
-     * Performs sequential GET request to the BigCommerce Management API at the specified endpoint. Concatenates results from all pages.
+     * Performs sequential GET request to the BigCommerce Management API at the specified endpoint. Concatenates result from all pages.
      * @async
      * @returns {object[]} Concatenated JSON data returned from a 2-- request
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const fetch = require('node-fetch')
-const querystring = require('querystring')
+const fetch = require("node-fetch")
+const querystring = require("querystring")
 
 module.exports = class {
     /**
@@ -10,12 +10,12 @@ module.exports = class {
      * @param {number} timeout Max time in millis for timeout (default: 15000)
      * @param {number} maxAttempts Number of retry attempts on timeout (default: 3)
      */
-    constructor(hash, token, debug=false, timeout=15000, maxAttempts=3){
+    constructor(hash, token, debug = false, timeout = 15000, maxAttempts = 3) {
         this.base = `https://api.bigcommerce.com/stores/${hash}/`
         this.headers = {
-            'X-Auth-Token':token,
-            'Accept':'application/json',
-            'Content-Type':'application/json'
+            "X-Auth-Token": token,
+            Accept: "application/json",
+            "Content-Type": "application/json",
         }
         this.meta = {}
         this.debug = debug
@@ -31,45 +31,47 @@ module.exports = class {
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'})
      */
-    async get(endpoint, queries={}){
+    async get(endpoint, queries = {}) {
         const url = `${this.base}${endpoint}?${querystring.stringify(queries)}`
         return this.readResponse(url)
     }
 
     /**
      * Performs sequential GET requests to the BigCommerce Management API at the specified endpoint. For each page in query it will perform the provided callback, passing an array of objects in page.
-     * @async
-     * @returns {null}
+     * @generator
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'}). Page & limit can be passed to control start & page size.
-     * @param {number} concurrency Amount of concurrent requests to make. Isn't a
+     * @param {number} concurrency Amount of concurrent requests to make
+     * @yields {Promise<[Array, number, number]>}
      */
-    async* paginate(endpoint, queries={}, concurrency=3){
+    async *paginate(endpoint, queries = {}, concurrency = 3) {
         const page = await this.get(endpoint, queries)
         const current = this.meta.pagination.current_page
         let total = this.meta.pagination.total_pages
 
-        yield [page, current, total];
+        yield [page, current, total]
 
-        if (this.debug) console.log('CURRENT PAGE:', current, 'TOTAL PAGES:', total)
+        if (this.debug) console.log("CURRENT PAGE:", current, "TOTAL PAGES:", total)
         if (current === total) return
 
-        for (let current_page = current + 1; current_page <= total; current_page += concurrency){
-            const pages = await Promise.all([ // Produces an array of concurrent request results
+        for (let current_page = current + 1; current_page <= total; current_page += concurrency) {
+            const pages = await Promise.all([
+                // Produces an array of concurrent request results
                 ...(() => {
                     const requests = []
                     for (let count = 0; count < concurrency; count++) {
                         queries.page = current_page + count
-                        if (queries.page <= total) // Skip requests outside of total pages
+                        if (queries.page <= total)
+                            // Skip requests outside of total pages
                             requests.push(this.get(endpoint, queries)) // Create one request per concurrency
                     }
                     return requests
-                })()
+                })(),
             ])
 
             for (const page of pages) yield [page, current_page, total]
 
-            if (this.debug) console.log('CURRENT PAGE:', current_page, 'TOTAL PAGES:', total)
+            if (this.debug) console.log("CURRENT PAGE:", current_page, "TOTAL PAGES:", total)
         }
     }
 
@@ -80,10 +82,10 @@ module.exports = class {
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'})
      */
-    async getAll(endpoint, queries={}){
+    async getAll(endpoint, queries = {}) {
         let result = []
 
-        for await(const items of this.paginate(endpoint, queries)) result = result.concat(items)
+        for await (const items of this.paginate(endpoint, queries)) result = result.concat(items)
 
         return result
     }
@@ -95,9 +97,9 @@ module.exports = class {
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} body Request body to be serialized and sent to endpoint
      */
-    async post(endpoint, body={}){
+    async post(endpoint, body = {}) {
         const url = `${this.base}${endpoint}`
-        return this.readResponse(url, "POST",  JSON.stringify(body))
+        return this.readResponse(url, "POST", JSON.stringify(body))
     }
 
     /**
@@ -107,9 +109,9 @@ module.exports = class {
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} body Request body to be serialized and sent to endpoint
      */
-    async put(endpoint, body){
+    async put(endpoint, body) {
         const url = `${this.base}${endpoint}`
-        return this.readResponse(url, "PUT",  JSON.stringify(body))
+        return this.readResponse(url, "PUT", JSON.stringify(body))
     }
 
     /**
@@ -118,7 +120,7 @@ module.exports = class {
      * @param {string} endpoint Url endpoint from version onward (example: 'v3/catalog/products')
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'})
      */
-    async delete(endpoint, queries={}){
+    async delete(endpoint, queries = {}) {
         const url = `${this.base}${endpoint}?${querystring.stringify(queries)}`
         return this.readResponse(url, "DELETE")
     }
@@ -130,41 +132,47 @@ module.exports = class {
      * @param {object} queries Object w/ keys & string values of each url query parameter (example: {sku:'10205'}).
      * @param {number} limit Amount of concurrent delete requests that will be performed. If the default setting of 3 errors out, set it to 1.
      */
-     async deleteAll(endpoint, queries={}, limit=3){
+    async deleteAll(endpoint, queries = {}, limit = 3) {
         queries.limit = limit
         let items = await this.get(endpoint, queries)
-        while (items.length){
-            await Promise.all(items.map((item)=>
-                this.delete(endpoint + '/' + item.id)
-            ))
+        while (items.length) {
+            await Promise.all(items.map((item) => this.delete(endpoint + "/" + item.id)))
             items = await this.get(endpoint, queries)
         }
     }
 
-    async readResponse(url, method="GET", body=undefined, attempts=0){
-        if(this.debug) console.log(method, url)
-        this.status = undefined;
+    async readResponse(url, method = "GET", body = undefined, attempts = 0) {
+        if (this.debug) console.log(method, url)
+        this.status = undefined
 
         try {
-            const response = await fetch(url, { method, headers:this.headers, timeout:this.timeout, body });
-            this.status = response.status;
+            const response = await fetch(url, {
+                method,
+                headers: this.headers,
+                timeout: this.timeout,
+                body,
+            })
+            this.status = response.status
 
-            if(!response.ok) {
-                if(response.status >= 500 && attempts < this.maxAttempts)
+            if (!response.ok) {
+                if (response.status >= 500 && attempts < this.maxAttempts)
                     return this.readResponse(url, method, body, attempts + 1)
                 else
-                    throw new Error(`${response.status} - ${response.statusText}: ${await response.text()}`);
+                    throw new Error(
+                        `${response.status} - ${response.statusText}: ${await response.text()}`
+                    )
             }
 
-            const result = await response.text();
-            if(result.length) {
+            const result = await response.text()
+            if (result.length) {
                 const body = JSON.parse(result)
                 this.meta = body.meta
-                return body.data ? body.data : body;
-            } else return response.status;
-
-        } catch(e) {
-            throw e;
+                return body.data ? body.data : body
+            } else {
+                return response.status
+            }
+        } catch (e) {
+            throw e
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,63 @@
 {
   "name": "bigcommerce-client",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "1.4.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "bigcommerce-client",
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "prettier": "^2.5.1"
+      },
+      "devDependencies": {
+        "@types/node": "^17.0.8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
   "dependencies": {
+    "@types/node": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "author": "Hunter Shaw",
   "license": "ISC",
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "prettier": "^2.5.1"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.8"
   }
 }


### PR DESCRIPTION
This would solve #5 

After looking into the code more i realized that technically you can achieve the same result through the `eachPage` parameter, but I feel this is a cleaner use

This also adds the ability to know where in the query we are by returning a tuple of the page items, and the current page, and total. Ideally, we might just return the meta itself so we can have an exact understanding of how many items we are getting in total, not just the pages